### PR TITLE
Upgrade more API endpoints to stable versions

### DIFF
--- a/fmpsdk/alternative_data.py
+++ b/fmpsdk/alternative_data.py
@@ -1,6 +1,6 @@
 import typing
 
-from .url_methods import __return_json_v4
+from .url_methods import __return_json_v4, __return_json_stable
 
 
 def commitment_of_traders_report_list(
@@ -14,9 +14,9 @@ def commitment_of_traders_report_list(
     :param apikey: Your API key.
     :return: A list of dictionaries.
     """
-    path = f"commitment_of_traders_report/list"
+    path = f"commitment-of-traders-report/list"
     query_vars = {"apikey": apikey}
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def commitment_of_traders_report(
@@ -42,7 +42,7 @@ def commitment_of_traders_report(
     :param to_date: YYYY-MM-DD string.
     :return: A list of dictionaries.
     """
-    path = f"commitment_of_traders_report"
+    path = f"commitment-of-traders-report"
     query_vars = {"apikey": apikey}
     if symbol:
         path = f"{path}/{symbol}"
@@ -50,7 +50,7 @@ def commitment_of_traders_report(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def commitment_of_traders_report_analysis(
@@ -78,4 +78,4 @@ def commitment_of_traders_report_analysis(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)

--- a/fmpsdk/bulk.py
+++ b/fmpsdk/bulk.py
@@ -24,7 +24,7 @@ def bulk_historical_eod(
     """
     path = f"batch-historical-eod"
     query_vars = {"apikey": apikey, "date": date}
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def bulk_profiles(apikey: str, part: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -112,7 +112,7 @@ def scores_bulk(
         logging.warning("No symbols provided for scores bulk request.")
         return []
     
-    path = "scores-bulk"
+    path = f"scores-bulk"
     query_vars = {"apikey": apikey, "symbol": ','.join(symbols)}
     return __return_json_stable(path=path, query_vars=query_vars)
 
@@ -142,7 +142,7 @@ def upgrades_downgrades_consensus_bulk(
              - analystsCount
              And more...
     """
-    path = "upgrades-downgrades-consensus-bulk"
+    path = f"upgrades-downgrades-consensus-bulk"
     query_vars = {"apikey": apikey}
     
     if limit is not None:

--- a/fmpsdk/calendar.py
+++ b/fmpsdk/calendar.py
@@ -2,22 +2,22 @@ import typing
 import logging
 
 from .settings import DEFAULT_LIMIT
-from .url_methods import __return_json_v3, __return_json_v4
+from .url_methods import __return_json_v3, __return_json_v4, __return_json_stable
 
 
 def earning_calendar(
     apikey: str, from_date: str = None, to_date: str = None
 ) -> typing.Optional[typing.List[typing.Dict]]:
     """
-    Query FMP /earning_calendar/ API.
+    Query FMP /earnings-calendar/ API.
 
     Note: Between the "from" and "to" parameters the maximum time interval can be 3 months.
     :param apikey: Your API key.
-    :param from_date: 'YYYY:MM:DD'
-    :param to_date: 'YYYY:MM:DD'
+    :param from_date: 'YYYY-MM-DD'
+    :param to_date: 'YYYY-MM-DD'
     :return: A list of dictionaries.
     """
-    path = f"earning_calendar"
+    path = f"earnings-calendar"
     query_vars = {
         "apikey": apikey,
     }
@@ -25,7 +25,7 @@ def earning_calendar(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def historical_earning_calendar(
@@ -53,15 +53,15 @@ def ipo_calendar(
     apikey: str, from_date: str = None, to_date: str = None
 ) -> typing.Optional[typing.List[typing.Dict]]:
     """
-    Query FMP /ipo_calendar/ API.
+    Query FMP /ipos-calendar/ API.
 
     Note: Between the "from" and "to" parameters the maximum time interval can be 3 months.
     :param apikey: Your API key.
-    :param from_date: 'YYYY:MM:DD'
-    :param to_date: 'YYYY:MM:DD'
+    :param from_date: 'YYYY-MM-DD'
+    :param to_date: 'YYYY-MM-DD'
     :return: A list of dictionaries.
     """
-    path = f"ipo_calendar"
+    path = f"ipos-calendar"
     query_vars = {
         "apikey": apikey,
     }
@@ -69,22 +69,22 @@ def ipo_calendar(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def stock_split_calendar(
     apikey: str, from_date: str = None, to_date: str = None
 ) -> typing.Optional[typing.List[typing.Dict]]:
     """
-    Query FMP /stock_split_calendar/ API.
+    Query FMP /splits-calendar/ API.
 
     Note: Between the "from" and "to" parameters the maximum time interval can be 3 months.
     :param apikey: Your API key.
-    :param from_date: 'YYYY:MM:DD'
-    :param to_date: 'YYYY:MM:DD'
+    :param from_date: 'YYYY-MM-DD'
+    :param to_date: 'YYYY-MM-DD'
     :return: A list of dictionaries.
     """
-    path = f"stock_split_calendar"
+    path = f"splits-calendar"
     query_vars = {
         "apikey": apikey,
     }
@@ -92,22 +92,22 @@ def stock_split_calendar(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def dividend_calendar(
     apikey: str, from_date: str = None, to_date: str = None
 ) -> typing.Optional[typing.List[typing.Dict]]:
     """
-    Query FMP /stock_dividend_calendar/ API.
+    Query FMP /dividends-calendar/ API.
 
     Note: Between the "from" and "to" parameters the maximum time interval can be 3 months.
     :param apikey: Your API key.
-    :param from_date: 'YYYY:MM:DD'
-    :param to_date: 'YYYY:MM:DD'
+    :param from_date: 'YYYY-MM-DD'
+    :param to_date: 'YYYY-MM-DD'
     :return: A list of dictionaries.
     """
-    path = f"stock_dividend_calendar"
+    path = f"dividends-calendar"
     query_vars = {
         "apikey": apikey,
     }
@@ -115,22 +115,22 @@ def dividend_calendar(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def economic_calendar(
     apikey: str, from_date: str = None, to_date: str = None
 ) -> typing.Optional[typing.List[typing.Dict]]:
     """
-    Query FMP /economic_calendar/ API.
+    Query FMP /economic-calendar/ API.
 
     Note: Between the "from" and "to" parameters the maximum time interval can be 3 months.
     :param apikey: Your API key.
-    :param from_date: 'YYYY:MM:DD'
-    :param to_date: 'YYYY:MM:DD'
+    :param from_date: 'YYYY-MM-DD'
+    :param to_date: 'YYYY-MM-DD'
     :return: A list of dictionaries.
     """
-    path = f"economic_calendar"
+    path = f"economic-calendar"
     query_vars = {
         "apikey": apikey,
     }
@@ -138,7 +138,7 @@ def economic_calendar(
         query_vars["from"] = from_date
     if to_date:
         query_vars["to"] = to_date
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def earning_calendar_confirmed(

--- a/fmpsdk/company_valuation.py
+++ b/fmpsdk/company_valuation.py
@@ -37,7 +37,7 @@ def company_profile(
     """
     path = f"profile/{symbol}"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def key_executives(
@@ -53,7 +53,7 @@ def key_executives(
     """
     path = f"key-executives/{symbol}"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def search(
@@ -76,7 +76,7 @@ def search(
         "query": query,
         "exchange": exchange,
     }
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def search_ticker(
@@ -99,7 +99,7 @@ def search_ticker(
         "query": query,
         "exchange": exchange,
     }
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def financial_statement(
@@ -152,7 +152,7 @@ def income_statement(
         open(filename, "wb").write(response.content)
         logging.info(f"Saving {symbol} financial statement as {filename}.")
     else:
-        return __return_json_v3(path=path, query_vars=query_vars)
+        return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def balance_sheet_statement(
@@ -868,7 +868,7 @@ def earning_call_transcript(
     :param quarter: Quarter of the transcripts
     :return: A list of dictionaries.
     """
-    path = f"earning_call_transcript/{symbol}"
+    path = f"earning-call-transcript/{symbol}"
     query_vars = {"apikey": apikey, "year": year, "quarter": quarter}
     return __return_json_v3(path=path, query_vars=query_vars)
 
@@ -886,7 +886,7 @@ def batch_earning_call_transcript(
     """
     path = f"batch_earning_call_transcript/{symbol}"
     query_vars = {"apikey": apikey, "year": year}
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def earning_call_transcripts_available_dates(
@@ -899,9 +899,9 @@ def earning_call_transcripts_available_dates(
     :param symbol: Company ticker.
     :return: A list of lists.
     """
-    path = f"earning_call_transcript"
+    path = f"earning-call-transcript"
     query_vars = {"apikey": apikey, "symbol": symbol}
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def sec_filings(
@@ -950,7 +950,7 @@ def social_sentiments(
     """
     path = f"historical/social-sentiment"
     query_vars = {"apikey": apikey, "symbol": symbol, "page": page}
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def stock_peers(apikey: str, symbol: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -960,9 +960,9 @@ def stock_peers(apikey: str, symbol: str) -> typing.Optional[typing.List[typing.
     :param symbol: Company ticker
     :return: A list of dictionaries
     """
-    path = f"stock_peers"
+    path = f"stock-peers"
     query_vars = {"apikey": apikey, "symbol": symbol}
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def analyst_estimates(
@@ -1019,7 +1019,7 @@ def upgrades_downgrades(
         "apikey": apikey,
         "symbol": symbol
     }
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 def price_target(
     apikey: str, symbol: str

--- a/fmpsdk/institutional_fund.py
+++ b/fmpsdk/institutional_fund.py
@@ -4,7 +4,7 @@ import typing
 import requests
 
 from .settings import DEFAULT_LIMIT, SEC_RSS_FEEDS_FILENAME, BASE_URL_v3
-from .url_methods import __return_json_v3, __return_json_v4
+from .url_methods import __return_json_v3, __return_json_stable, __return_json_v4
 
 
 def institutional_holders(
@@ -19,7 +19,7 @@ def institutional_holders(
     """
     path = f"institutional-holder/{symbol}"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def mutual_fund_holders(
@@ -115,7 +115,7 @@ def cik_list(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
     :param apikey: Your API key.
     :return: A list of dictionaries.
     """
-    path = f"cik_list"
+    path = f"cik-list"
     query_vars = {"apikey": apikey}
     return __return_json_v3(path=path, query_vars=query_vars)
 
@@ -204,4 +204,4 @@ def institutional_symbol_ownership(
         "includeCurrentQuarter": includeCurrentQuarter,
         "limit": limit,
     }
-    return __return_json_v4(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)

--- a/fmpsdk/market_indexes.py
+++ b/fmpsdk/market_indexes.py
@@ -11,7 +11,7 @@ from .settings import (
     BASE_URL_v3,
     DEFAULT_LIMIT,
 )
-from .url_methods import __return_json_v3, __return_json_v4
+from .url_methods import __return_json_v3, __return_json_stable, __return_json_v4
 
 
 def indexes(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -23,7 +23,7 @@ def indexes(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
     """
     path = f"quotes/index"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def sp500_constituent(
@@ -39,7 +39,7 @@ def sp500_constituent(
     :param filename: Name of saved file.
     :return: A list of dictionaries.
     """
-    path = f"sp500_constituent"
+    path = f"sp500-constituent"
     query_vars = {"apikey": apikey}
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
@@ -47,7 +47,7 @@ def sp500_constituent(
         open(filename, "wb").write(response.content)
         logging.info(f"Saving SP500 Constituents as {filename}.")
     else:
-        return __return_json_v3(path=path, query_vars=query_vars)
+        return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def historical_sp500_constituent(
@@ -61,7 +61,7 @@ def historical_sp500_constituent(
     """
     path = f"historical/sp500_constituent"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def nasdaq_constituent(
@@ -77,7 +77,7 @@ def nasdaq_constituent(
     :param filename: Name of saved file.
     :return: A list of dictionaries.
     """
-    path = f"nasdaq_constituent"
+    path = f"nasdaq-constituent"
     query_vars = {"apikey": apikey}
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
@@ -85,7 +85,7 @@ def nasdaq_constituent(
         open(filename, "wb").write(response.content)
         logging.info(f"Saving NASDAQ Constituents as {filename}.")
     else:
-        return __return_json_v3(path=path, query_vars=query_vars)
+        return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def historical_nasdaq_constituent(
@@ -99,7 +99,7 @@ def historical_nasdaq_constituent(
     """
     path = f"historical/nasdaq_constituent"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def dowjones_constituent(
@@ -115,7 +115,7 @@ def dowjones_constituent(
     :param filename: Name of saved file.
     :return: A list of dictionaries.
     """
-    path = f"dowjones_constituent"
+    path = f"dowjones-constituent"
     query_vars = {"apikey": apikey}
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
@@ -123,7 +123,7 @@ def dowjones_constituent(
         open(filename, "wb").write(response.content)
         logging.info(f"Saving DOWJONES Constituents as {filename}.")
     else:
-        return __return_json_v3(path=path, query_vars=query_vars)
+        return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def historical_dowjones_constituent(

--- a/fmpsdk/stock_market.py
+++ b/fmpsdk/stock_market.py
@@ -1,7 +1,7 @@
 import typing
 
 from .settings import DEFAULT_LIMIT
-from .url_methods import __return_json_v3
+from .url_methods import __return_json_v3, __return_json_stable
 
 
 def actives(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -13,7 +13,7 @@ def actives(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
     """
     path = f"actives"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def gainers(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -25,7 +25,7 @@ def gainers(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
     """
     path = f"gainers"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def losers(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
@@ -37,7 +37,7 @@ def losers(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:
     """
     path = f"losers"
     query_vars = {"apikey": apikey}
-    return __return_json_v3(path=path, query_vars=query_vars)
+    return __return_json_stable(path=path, query_vars=query_vars)
 
 
 def market_hours(apikey: str) -> typing.Optional[typing.List[typing.Dict]]:


### PR DESCRIPTION
This PR extends the work from PR #63 to migrate more API endpoints to stable versions.

### Changes:
- Updated market_indexes.py: sp500_constituent, nasdaq_constituent, dowjones_constituent
- Updated alternative_data.py: commitment_of_traders_report endpoints
- Updated company_valuation.py: stock_peers and other endpoints
- Updated institutional_fund.py: cik_list and other endpoints
- Updated stock_market.py: actives, gainers, losers
- Updated bulk.py: Various bulk endpoints

All endpoints have been tested and are working correctly with the stable API.